### PR TITLE
Detecting pipe failures prevents result reporting

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
-set -o pipefail
 
 function main() {
     echo "Running Validator"


### PR DESCRIPTION
Having `pipefail` set in the `entrypoint.sh` stops failures being reported if `html5validator` does actually return a non-zero code.

You can see this in the logs from the action-test here:
https://github.com/Cyb3r-Jak3/html5validator-action/runs/936410945?check_suite_focus=true

For the "Plain test" step, we see this output:
```bash
Running Validator
+ BuildARGS=
+ uses ''
+ '[' -n '' ']'
+ usesBoolean false
+ '[' -n false ']'
+ '[' false = true ']'
+ uses ''
+ '[' -n '' ']'
+ tee log.log
+ html5validator --root tests/valid/ --log WARNING
+ result=0
0
+ usesBoolean true
+ '[' -n true ']'
+ '[' true = true ']'
+ echo 0
+ echo ::set-output name=result::0
```

But for the "Check failure" step, we see this:
```bash
+ BuildARGS=
+ uses ''
+ '[' -n '' ']'
+ usesBoolean true
+ '[' -n true ']'
+ '[' true = true ']'
+ BuildARGS+=' --also-check-css'
+ uses -lll
+ '[' -n -lll ']'
+ BuildARGS+=' -lll'
+ html5validator --root tests/invalid/ --log INFO --also-check-css -lll
+ tee log.log
Running Validator
INFO:html5validator.cli:Files to validate: 
  tests/invalid/index.html
  tests/invalid/style.css
INFO:html5validator.cli:Number of files: 2
ERROR:html5validator.validator:['"file:/github/workspace/tests/invalid/index.html":0.1-0.6: error: Start tag seen without seeing a doctype first. Expected "<!DOCTYPE html>".', '"file:/github/workspace/tests/invalid
```

Note that the lines after `+ html5validator --root tests/valid/ --log WARNING` in the "Plain test" don't get reported in the "Check Failure" case.

Doing a quick test with this PR seemed to give the correct behavior.