### PR TITLE
Switch to Github Container Repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cyb3rjak3/html5validator:source-alpine
+FROM ghcr.io/cyb3r-jak3/html5validator:source-alpine 
 
 COPY entrypoint.sh /entrypoint.sh
 RUN apk add --update bash && rm -rf /var/cache/apk/*

--- a/action.yml
+++ b/action.yml
@@ -23,12 +23,10 @@ inputs:
     default: "WARNING"
   css:
     description: "Checks css as well"
-    require: false
-    default: false
+    required: false
   action_debug:
     description: "Flag that increase verbose output only used for troubleshooting the action."
     required: false
-    default: false
 outputs:
   result:
     description: 'The exit code'


### PR DESCRIPTION
- Switch to using the Html5validator image from GitHub's container registry. [Image Link](https://github.com/users/Cyb3r-Jak3/packages/container/package/html5validator)
