### PR TITLE
Adds in test for misisng root

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -81,7 +81,7 @@ jobs:
       continue-on-error: true
 
     - name: Check Bad Root
-      id: bad_root
+      id: badRoot
       uses: ./
       with:
         root: /tmp/missing
@@ -102,4 +102,4 @@ jobs:
         CONFIG_OUT: ${{ steps.config.outputs.result }}
         BLACKLIST_OUT: ${{ steps.blacklist.outputs.result }}
         EMPTY_OUT: ${{ steps.empty.outputs.result }}
-        BAD_ROOT_OUT: ${{ steps.empty.bad_root.result }}
+        BAD_ROOT_OUT: ${{ steps.empty.badRoot.result }}

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -80,6 +80,15 @@ jobs:
         css: true
       continue-on-error: true
 
+    - name: Check Bad Root
+      id: bad_root
+      uses: ./
+      with:
+        root: /tmp/missing
+        log_level: INFO
+        css: true
+      continue-on-error: true
+
     - uses: actions/upload-artifact@v3
       with:
         name: log
@@ -93,3 +102,4 @@ jobs:
         CONFIG_OUT: ${{ steps.config.outputs.result }}
         BLACKLIST_OUT: ${{ steps.blacklist.outputs.result }}
         EMPTY_OUT: ${{ steps.empty.outputs.result }}
+        BAD_ROOT_OUT: ${{ steps.empty.bad_root.result }}

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -81,7 +81,7 @@ jobs:
       continue-on-error: true
 
     - name: Check Bad Root
-      id: badRoot
+      id: bad-root
       uses: ./
       with:
         root: /tmp/missing
@@ -102,4 +102,4 @@ jobs:
         CONFIG_OUT: ${{ steps.config.outputs.result }}
         BLACKLIST_OUT: ${{ steps.blacklist.outputs.result }}
         EMPTY_OUT: ${{ steps.empty.outputs.result }}
-        BAD_ROOT_OUT: ${{ steps.empty.badRoot.result }}
+        BAD_ROOT_OUT: ${{ steps.bad-root.outputs.result }}

--- a/tests/output_check.sh
+++ b/tests/output_check.sh
@@ -19,3 +19,8 @@ if [[ "$EMPTY_OUT" != "no config file or root path given" ]]; then
  echo "Empty check failed"
  exit 1; 
 fi
+
+if [[ "$BAD_ROOT_OUT" != 1 ]]; then
+    echo "Badd root check failed"
+    exit 1;
+fi

--- a/tests/output_check.sh
+++ b/tests/output_check.sh
@@ -20,7 +20,7 @@ if [[ "$EMPTY_OUT" != "no config file or root path given" ]]; then
  exit 1; 
 fi
 
-if [[ "$BAD_ROOT_OUT" != 1 ]]; then
-    echo "Badd root check failed"
+if [[ "$BAD_ROOT_OUT" -ne 1 ]]; then
+    echo "Bad root check failed"
     exit 1;
 fi


### PR DESCRIPTION
### What does this PR accomplish

Now that html5validator exits 1 when there is no root found ([PR](https://github.com/svenkreiss/html5validator/issues/91)), a test has been added to check for it

### Related issues

Resolves #27 

### Tests

* [X] Github Actions Pass

### Update File

* [X] Changelog updated